### PR TITLE
delete adddevice in navbar

### DIFF
--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -93,7 +93,7 @@ export default {
   name: "NavBar",
   data() {
     return {
-      links: ["Home", "AddSensor", "Sensors", "QR-scanner", "About"],
+      links: ["Home", "Sensors", "QR-scanner", "About"],
     };
   },
 };


### PR DESCRIPTION
because you can now add a device from the device list